### PR TITLE
Tweak FileSystemWatcher

### DIFF
--- a/roles/sc2_host/defaults/main.yml
+++ b/roles/sc2_host/defaults/main.yml
@@ -5,7 +5,5 @@ starcraft_registry_path: 'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVe
 python_registry_path: 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*'
 
 drive_letter: 'C'
-account_number: 999999
-account_other: 'other'
 scripts_dir: '{{ drive_letter }}:\Documents\replays_scripts'
-replays_dir: '{{ drive_letter }}:\Documents\StarCraft II\Accounts\{{ account_number }}\{{ account_other }}\Replays'
+replays_dir: '{{ drive_letter }}:\Documents\StarCraft II\Accounts\'

--- a/roles/sc2_host/templates/watch_for_replays.ps1
+++ b/roles/sc2_host/templates/watch_for_replays.ps1
@@ -1,8 +1,5 @@
 $sb={
      $name = $Event.SourceEventArgs.FullPath
-     $changeType = $Event.SourceEventArgs.ChangeType
-     $timeStamp = $Event.TimeGenerated
-     Write-Host "The file $name was $changeType at $timeStamp" -fore green
      swift auth
      swift upload replays_unprocessed $name
      $event


### PR DESCRIPTION
* watch_for_replays.ps1 now watches for subdirectories of the Starcraft
  II folder in Documents, eliminating the need to key in battle.net
  credentials on a per-host basis.

* removes some extraneous actions and variables from watch_for_replays

Signed-off-by: Cullen Taylor <cullentaylor@outlook.com>