### PR TITLE
Ensure FileSystemWatcher runs in the background

### DIFF
--- a/roles/sc2_host/tasks/main.yml
+++ b/roles/sc2_host/tasks/main.yml
@@ -60,7 +60,7 @@
 - name: Ensure watch script
   win_template:
     src: watch_for_replays.ps1
-    dest: '{{ scripts_dir }}\watch_for_replays.ps1'
+    dest: 'powershell.exe -File {{ scripts_dir }}\watch_for_replays.ps1 -WindowStyle Hidden'
 
 - name: Start watching for SC2Replay files
   raw: 'powershell.exe {{ scripts_dir }}\watch_for_replays.ps1'


### PR DESCRIPTION
It would be nice if the FileSystemWatcher actually, you know, watched
for replays!

Signed-off-by: Cullen Taylor <cullentaylor@outlook.com>