### PR TITLE
Bugfixes to replay_proc role

### DIFF
--- a/roles/replay_proc/defaults/main.yml
+++ b/roles/replay_proc/defaults/main.yml
@@ -3,7 +3,6 @@ watson_secrets:
   client_id: "default"
   client_secret: "default"
   refresh_token: "default"
-  access_token: "default"
   dataset_id: "default"
 
 base_api_link: "https://api.ibm.com/watsonanalytics/run"

--- a/roles/replay_proc/tasks/main.yml
+++ b/roles/replay_proc/tasks/main.yml
@@ -26,14 +26,14 @@
   with_items:
     - python-keystoneclient
     - python-swiftclient
-    - git+https://github.com/nibalizer/replay_processing.git
+    - git+git://github.com/nibalizer/replay_processing.git#egg=replay_processing
 
 - name: Ensure directories
   file:
     path: "{{ item }}"
     state: directory
   with_items:
-    - /opt/scripts
+    - /opt/replays/scripts
     - /opt/replays/replays_unprocessed
     - /opt/replays/replays_processed
 


### PR DESCRIPTION
* scripts_dir was not being created in /opt/scripts rather than the
  expected /opt/replays/scripts (typo).

* removed extraneous auth_token variable, as it is no longer used now
  that auth tokens are granted via a static refresh token from Watson
  Analytics.

* Fixed pip install of replay_processing so it is installed from source
  correctly.

Signed-off-by: Cullen Taylor <cullentaylor@outlook.com>